### PR TITLE
データベース設計　修正３

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :users, through: groups_users
 - has_many :groups_users
-- has_many :messages
 
 ## groups_users table
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 # DB設計
-## groups_usersテーブル
+## users table
 
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false,index: true,unique:true|
+|password|string|null: false,index: true,unique:true|
+|nickname|string|null: false,index: true,unique:true|
+
+### Association
+- has_many :groups, through: groups_users
+- has_many :groups_users
+- has_many :messages
+
+## messages table
+
+|Column|Type|Options|
+|------|----|-------|
+|text|text||
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groups table
+
+|Column|Type|Options|
+|------|----|-------|
+|group|text||
+|menber|text||
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :users, through: groups_users
+- has_many :groups_users
+- belongs_to :user
+
+## groups_users table
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 |Column|Type|Options|
 |------|----|-------|
 |text|text||
+|image|text||
 |user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :user
@@ -28,13 +30,12 @@
 |Column|Type|Options|
 |------|----|-------|
 |group|text||
-|menber|text||
-|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :users, through: groups_users
 - has_many :groups_users
-- belongs_to :user
+- belongs_to :messages
 
 ## groups_users table
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -29,13 +29,12 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|group|text||
-|group_id|integer|null: false, foreign_key: true|
+|name|text|null: false|
 
 ### Association
 - has_many :users, through: groups_users
 - has_many :groups_users
-- belongs_to :messages
+- has_many :messages
 
 ## groups_users table
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 ### Association
 - has_many :users, through: groups_users
 - has_many :groups_users
+- has_many :messages
 
 ## groups_users table
 |Column|Type|Options|


### PR DESCRIPTION
What
1. groupテーブルのTypeのtextをstringに変更。

2. groupテーブルのhas_many: messagesを削除。

Why
1. textでは大きすぎるため。

2. group-usersのアソシエーションのみでいいから。